### PR TITLE
Refactor ComponentSerializer for improved error handling

### DIFF
--- a/core/01_ECS_core/component_serializer.cpp
+++ b/core/01_ECS_core/component_serializer.cpp
@@ -1,54 +1,65 @@
 /**
  * @file component_serializer.cpp
  * @brief Implementation of the ComponentSerializer class.
- * * Handles the string parsing and dictionary lookups required to convert
- * live ECS memory into savable text blocks and back again.
  */
 
 #include "component_serializer.hpp"
+#include <sstream>
+#include <iostream>
 
-void ComponentSerializer::registerComponent(const std::string& name, SerializeFunc serialize, DeserializeFunc deserialize) {
-    serializers[name] = serialize;
-    deserializers[name] = deserialize;
-
-    registered_components.push_back(name);
+void ComponentSerializer::registerComponent(
+    const std::string& name,
+    std::function<std::string(entt::registry&, EntityID)> save_fn,
+    std::function<void(entt::registry&, EntityID, const std::string&)> load_fn)
+{
+    // Prevent duplicate entries in the name list if registered multiple times
+    if (serializers.find(name) == serializers.end()) {
+        registered_components.push_back(name);
+    }
+    serializers[name] = save_fn;
+    deserializers[name] = load_fn;
 }
 
 std::string ComponentSerializer::serializeEntity(entt::registry& registry, EntityID entity) {
-    std::string save_data = "";
+    std::ostringstream out;
+    out << "Entity:" << entity.raw_id << "\n";
 
     for (const auto& name : registered_components) {
-        std::string comp_data = serializers[name](registry, entity);
+        auto it = serializers.find(name);
 
-        if (!comp_data.empty()) {
-            save_data += "[" + name + "]:" + comp_data + ";\n";
+        //Ensure the key exists AND the function is not null before calling
+        if (it != serializers.end() && it->second) {
+            std::string comp_data = it->second(registry, entity);
+            if (!comp_data.empty()) {
+                out << "[" << name << "]:" << comp_data << "\n";
+            }
+        } else {
+            std::cerr << "[WARNING] ComponentSerializer: Missing or null serializer for '" << name << "'.\n";
         }
     }
-
-    return save_data;
+    return out.str();
 }
 
 void ComponentSerializer::deserializeEntity(entt::registry& registry, EntityID entity, const std::string& data) {
-    size_t current_pos = 0;
+    std::istringstream in(data);
+    std::string line;
 
-    while (current_pos < data.length()) {
-        size_t name_start = data.find('[', current_pos);
-        if (name_start == std::string::npos) break;
+    while (std::getline(in, line)) {
+        if (line.empty() || line.find("Entity:") == 0) continue;
 
-        size_t name_end = data.find("]:", name_start);
-        if (name_end == std::string::npos) break;
+        size_t bracket_end = line.find("]:");
+        if (line[0] == '[' && bracket_end != std::string::npos) {
+            std::string name = line.substr(1, bracket_end - 1);
+            std::string comp_data = line.substr(bracket_end + 2);
 
-        size_t data_end = data.find(";\n", name_end);
-        if (data_end == std::string::npos) break;
+            auto it = deserializers.find(name);
 
-        std::string name = data.substr(name_start + 1, name_end - name_start - 1);
-        std::string comp_data = data.substr(name_end + 2, data_end - name_end - 2);
-
-        auto it = deserializers.find(name);
-        if (it != deserializers.end()) {
-            it->second(registry, entity, comp_data);
+            // Prevents bad_function_call crash on outdated save files
+            if (it != deserializers.end() && it->second) {
+                it->second(registry, entity, comp_data);
+            } else {
+                std::cerr << "[WARNING] ComponentSerializer: No deserializer found for saved component '" << name << "'. Ignoring.\n";
+            }
         }
-
-        current_pos = data_end + 2;
     }
 }


### PR DESCRIPTION
Updated the serialization and deserialization methods to include error handling and prevent duplicate component registrations.

fix:
 auto it = serializers.find(name);
        if (it != serializers.end() && it->second) {
            std::string comp_data = it->second(registry, entity);
            if (!comp_data.empty()) {
                out << "[" << name << "]:" << comp_data << "\n";
            }
        } else {
            std::cerr << "[WARNING] ComponentSerializer: Missing or null serializer for '" << name << "'.\n";
        }